### PR TITLE
Send notifications to a #channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/francho/hubot-github-notify.git"
+    "url": "git://github.com/frapontillo/hubot-github-notify.git"
   },
   "bugs": {
     "url": "https://github.com/frapontillo/hubot-github-notify/issues"


### PR DESCRIPTION
Some adapters (like Slack) don't support private messages.

If HUBOT_GITHUB_CHANNEL environment variable is set, the notifications will be send to this channel
