### PR TITLE
fix bug when `notify me of...` command failed.

### DIFF
--- a/src/github-notify.coffee
+++ b/src/github-notify.coffee
@@ -284,7 +284,7 @@ module.exports = (robot) ->
     catch error
       reply = error
     finally
-      private_message robot, get_pm_user(msg.message.user), reply
+      private_message robot, get_pm_user(msg.message.user.name), reply
 
   # handle new comments and new issue assignments
   robot.router.post '/hubot/gh-notify', (req, res) ->


### PR DESCRIPTION
fix bug when notification already configured (I met this problem in slack)

In this context, `msg.message.user` is js object: not a string, it's not compatible to get_pm_user.