### PR TITLE
Adds slack compatibility.

### DIFF
--- a/src/github-notify.coffee
+++ b/src/github-notify.coffee
@@ -226,8 +226,9 @@ private_messages = (robot, users, message) ->
 #
 # Returns nothing.
 private_message = (robot, user, message) ->
+  message = '' + message
   user = get_pm_user user
-  robot.send {user: user}, message
+  robot.send {room: user.name, user: user}, message
 
 # Delete the reply_to information from a given User,
 # so that it is possible to force a private message on send.


### PR DESCRIPTION
Specifically I needed to add the user name as a room and convert
errors to strings. This allows github notify to work with slack.
