### PR TITLE
Update for newer Hubot and Hubot-Slack API

### DIFF
--- a/src/github-notify.coffee
+++ b/src/github-notify.coffee
@@ -228,7 +228,7 @@ private_messages = (robot, users, message) ->
 private_message = (robot, user, message) ->
   message = '' + message
   user = get_pm_user user
-  robot.send {room: user.name, user: user}, message
+  robot.messageRoom({room: user.room}, message)
 
 # Delete the reply_to information from a given User,
 # so that it is possible to force a private message on send.


### PR DESCRIPTION
Changed the way messages are sent with `robot.send`. The appropriate channel will now be correctly selected.